### PR TITLE
chore: set base font-size

### DIFF
--- a/src/components/app/common.ts
+++ b/src/components/app/common.ts
@@ -1,12 +1,17 @@
 import { css } from 'styled-components';
 
 export default css`
+  html {
+    font-size: 62.5%;
+  }
+
   html,
   body {
     height: 100%;
   }
 
   body {
+    font-size: 1.6rem;
     overflow-x: hidden;
     overflow-y: scroll;
   }


### PR DESCRIPTION
Setter font-size til 62.5% i base. Hvis browser font-size er 16px (som er vanlig default) blir det 10px. Gjør at vi kan bruke 'rem' med enkel omregning til px, f.eks. 1.6rem er 16px, 2rem = 20px osv.